### PR TITLE
Enabled dark and light mode with switch for docs using docsify-darklight-theme

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,12 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <meta name="description" content="A tiny state container. Like Redux, but smaller - and with way less boilerplate code">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/vue.css">
+  <link 
+    rel="stylesheet"
+    href="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/style.min.css"
+    title="docsify-darklight-theme"
+    type="text/css"
+  />
 </head>
 <body>
   <div id="app"></div>
@@ -24,6 +29,10 @@
       search: 'auto',
       subMaxLevel: 3,
     }
+  </script>
+  <script 
+    src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/index.min.js"
+    type="text/javascript">
   </script>
   <script src="//cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/prismjs/components/prism-bash.min.js"></script>


### PR DESCRIPTION
### Light Mode

![image](https://user-images.githubusercontent.com/10001746/83452536-856f9500-a476-11ea-9c11-5177a7c0d110.png)

### Dark mode

![image](https://user-images.githubusercontent.com/10001746/83452522-7ab50000-a476-11ea-9d73-0ad1933dbcf5.png)

