### PR TITLE
refactor: rename ModelStore.dispatch to getDispatch

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -201,7 +201,7 @@ export default createModel({
     // we want to dispatch actions in multiple effects so we can
     // capture the typed dispatch method from the store here instead
     // of repeating it
-    const dispatch = store.dispatch()
+    const dispatch = store.getDispatch()
 
     // this is also a great place to put other variables that may
     // need to be accessed from multiple effects such as firestore
@@ -341,7 +341,7 @@ export default createModel({
   },
 
   effects(store: Store) {
-    const dispatch = store.dispatch()
+    const dispatch = store.getDispatch()
 
     return {
       async signedOut() {
@@ -473,7 +473,7 @@ export default createModel({
   // state and reducers not shown
 
   effects(store: Store) {
-    const dispatch = store.dispatch()
+    const dispatch = store.getDispatch()
 
     return {
       async 'routing/change'(payload: RoutingState) {
@@ -520,7 +520,7 @@ export default createModel({
   },
 
   effects(store: Store) {
-    const dispatch = store.dispatch()
+    const dispatch = store.getDispatch()
 
     return {
       async 'routing/change'(payload: RoutingState) {

--- a/docs/api-createModel.md
+++ b/docs/api-createModel.md
@@ -180,7 +180,7 @@ export default createModel({
   effects(store: Store) {
     // this captures the strongly typed store dispatch
     // which effects can use to dispatch other actions
-    const dispatch = store.dispatch()
+    const dispatch = store.getDispatch()
 
     return {
       // this will be called _after_ the signedIn

--- a/docs/recipe-auth.md
+++ b/docs/recipe-auth.md
@@ -45,7 +45,7 @@ export default createModel({
   },
 
   effects(store: Store) {
-    const dispatch = store.dispatch()
+    const dispatch = store.getDispatch()
 
     return {
       // listen to firebase auth state changes and reflect in state

--- a/docs/recipe-firestore.md
+++ b/docs/recipe-firestore.md
@@ -55,7 +55,7 @@ export default createModel({
 
   effects(store: Store) {
     // capture the store dispatch method
-    const dispatch = store.dispatch()
+    const dispatch = store.getDispatch()
 
     // listListener will be used to keep track of the listener
     // for the list of todo items. Because we want to unsubscribe 

--- a/readme.md
+++ b/readme.md
@@ -364,7 +364,7 @@ export default createModel({
   // our async effects
   effects(store: Store) {
     // reference the dispatch method, which is used in multiple effects
-    const dispatch = store.dispatch()
+    const dispatch = store.getDispatch()
 
     // return the effect methods so they are wired up by the middleware
     return {

--- a/src/effectsPlugin.ts
+++ b/src/effectsPlugin.ts
@@ -16,7 +16,7 @@ export const effectsPlugin = {
     }
 
     const modelEffects = model.effects({
-      dispatch: () => store.dispatch,
+      getDispatch: () => store.dispatch,
       getState: () => store.state
     })
 

--- a/test/types/effects-config.ts
+++ b/test/types/effects-config.ts
@@ -11,7 +11,7 @@ export const testModel = createModel({
   effects: (store: Store) => ({
     async run(_payload: string) {
       // dispatch returns the typed, store dispatch
-      store.dispatch().test.add(10)
+      store.getDispatch().test.add(10)
 
       // getState returns the typed, store state
       const state = store.getState()

--- a/typings/model.d.ts
+++ b/typings/model.d.ts
@@ -13,11 +13,9 @@ interface EffectFns {
 }
 
 export interface ModelStore<D = any, S = any> {
-  // TODO: for consistency with state, rename dispatch to getDispatch (?)
-
-  // dispatch has to be a function that returns the Dispatch for the store
+  // getDispatch has to be a function that returns the Dispatch for the store
   // otherwise it creates a circular reference when added to the models' effects
-  dispatch: () => D
+  getDispatch: () => D
   getState: GetState<S>
 }
 


### PR DESCRIPTION
I changed dispatch to getDispatch in the ModelStore type, which is used when calling the `effects` factory method of a model.

⚠️  **BREAKING CHANGE** ⚠️ 

This API change will affect every `effects` branch of every model, that uses the store's dispatch. (That is pretty much every model, unless the effects are just triggering things outside of the model, e.g. calling out to tracking / logging services.)

closes #16